### PR TITLE
Added conversion rule for vowel a

### DIFF
--- a/eng_to_ipa/transcribe.py
+++ b/eng_to_ipa/transcribe.py
@@ -103,7 +103,7 @@ def get_cmu(tokens_in, db_type="sql"):
 
 def cmu_to_ipa(cmu_list, mark=True, stress_marking='all'):
     """converts the CMU word lists into IPA transcriptions"""
-    symbols = {"a": "ə", "ey": "eɪ", "aa": "ɑ", "ae": "æ", "ah": "ə", "ao": "ɔ",
+    symbols = {"a": "ə", "ey": "eɪ", "aa": "ɑ", "ae": "æ", "ah": "ʌ", "ao": "ɔ",
                "aw": "aʊ", "ay": "aɪ", "ch": "ʧ", "dh": "ð", "eh": "ɛ", "er": "ər",
                "hh": "h", "ih": "ɪ", "jh": "ʤ", "ng": "ŋ",  "ow": "oʊ", "oy": "ɔɪ",
                "sh": "ʃ", "th": "θ", "uh": "ʊ", "uw": "u", "zh": "ʒ", "iy": "i", "y": "j"}

--- a/eng_to_ipa/transcribe.py
+++ b/eng_to_ipa/transcribe.py
@@ -106,7 +106,7 @@ def cmu_to_ipa(cmu_list, mark=True, stress_marking='all'):
     symbols = {"a": "ə", "ey": "eɪ", "aa": "ɑ", "ae": "æ", "ah": "ʌ", "ao": "ɔ",
                "aw": "aʊ", "ay": "aɪ", "ch": "ʧ", "dh": "ð", "eh": "ɛ", "er": "ər",
                "hh": "h", "ih": "ɪ", "jh": "ʤ", "ng": "ŋ",  "ow": "oʊ", "oy": "ɔɪ",
-               "sh": "ʃ", "th": "θ", "uh": "ʊ", "uw": "u", "zh": "ʒ", "iy": "i", "y": "j"}
+               "sh": "ʃ", "th": "θ", "uh": "ʊ", "uw": "u", "zh": "ʒ", "iy": "iː", "y": "j"}
     final_list = []  # the final list of IPA tokens to be returned
     for word_list in cmu_list:
         ipa_word_list = []  # the word list for each word


### PR DESCRIPTION
@mphilli 

Currently, "up" is converted to /əp/.
After updating, it is converted to /ʌp/.

Oxford Online Dictionary: 
https://www.oxfordlearnersdictionaries.com/definition/english/up_1?q=up

I would appreciate it if you could merge it.